### PR TITLE
BUG: pass lambda explicitly to cv.grpreg

### DIFF
--- a/R/cv.grpreg.R
+++ b/R/cv.grpreg.R
@@ -1,4 +1,4 @@
-cv.grpreg <- function(X, y, group=1:ncol(X), ..., nfolds=10, seed, trace=FALSE) {
+cv.grpreg <- function(X, y, group=1:ncol(X), lambda, ..., nfolds=10, seed, trace=FALSE) {
   if (!missing(seed)) set.seed(seed)
   fit <- grpreg(X=X, y=y, group=group, ...)
   multi <- FALSE


### PR DESCRIPTION
Bug occurence:

```
library(grpreg)
X = matrix(rnorm(10000), ncol=10)
y = rnorm(1000)
mod = grpreg(X,y,1:ncol(X),lambda=c(2,1))
mod_cv = cv.grpreg(X,y,1:ncol(X),lambda=c(2,1))
> Error in grpreg(X1, y1, g, lambda = fit$lambda, warn = FALSE, ...) : 
>  formal argument "lambda" matched by multiple actual arguments
```

Reason:

Line 46 of cv.grpreg:

```
fit.i <- grpreg(X1, y1, g, lambda=fit$lambda, warn=FALSE, ...)
```

Which passes lambda twice, once explicitly, and once more implicitly through `...`

Solution: Just make lambda explicit in the cv.grpreg call.
