### PR TITLE
Add functionality to grpsurv for start stop survival times

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -5,7 +5,8 @@ Date: 2021-07-09
 Authors@R: c(
   person("Patrick", "Breheny", role=c("aut","cre"), email="patrick-breheny@uiowa.edu", comment=c(ORCID="0000-0002-0650-1119")),
   person("Yaohui", "Zeng", role="ctb"),
-  person("Ryan", "Kurth", role="ctb"))
+  person("Ryan", "Kurth", role="ctb"),
+  person("Jamie", "Wallis", role="ctb"))
 Depends: R (>= 3.1.0)
 Imports: Matrix
 Suggests: knitr, rmarkdown, splines, survival, tinytest

--- a/R/auc.R
+++ b/R/auc.R
@@ -4,7 +4,7 @@ AUC.cv.grpsurv <- function(obj, ...) {
     stop("The 'survival' package is needed for AUC() to work. Please install it.", call. = FALSE)
   }  
   if (packageVersion("survival") < "3.2.10") stop("AUC.cv.ncvsurv requires version 3.2.10 of 'survival' package or higher", call.=FALSE)
-  S <- survival::Surv(obj$fit$time, obj$fit$fail)
+  S <- survival::Surv(obj$fit$start_time, obj$fit$stop_time, obj$fit$fail)
   res <- apply(obj$Y, 2, concord, y = S)
   num <- res['concordant',] + 0.5*res['tied.x',] + 0.5*res['tied.y',] + 0.5*res['tied.xy',]
   num/sum(res[,1])

--- a/R/cv-grpsurv.R
+++ b/R/cv-grpsurv.R
@@ -11,7 +11,7 @@ cv.grpsurv <- function(X, y, group, ..., nfolds=10, seed, fold, se=c('quick', 'b
 
   # Get standardized X, y
   X <- fit$XG$X
-  y <- cbind(fit$time, fit$fail)
+  y <- cbind(fit$start_time, fit$stop_time, fit$fail)
   returnX <- list(...)$returnX
   if (is.null(returnX) || !returnX) fit$X <- NULL
 

--- a/R/loss.R
+++ b/R/loss.R
@@ -22,14 +22,28 @@ loss.grpreg <- function(y, yhat, family) {
   val
 }
 loss.grpsurv <- function(y, eta, total=TRUE) {
-  ind <- order(y[,1])
-  d <- as.integer(y[ind,2])
+  ind <- order(y[,2])
+  d <- as.integer(y[ind,3])
   if (is.matrix(eta)) {
     eta <- eta[ind, , drop=FALSE]
     r <- apply(eta, 2, function(x) rev(cumsum(rev(exp(x)))))
   } else {
     eta <- as.matrix(eta[ind])
     r <- as.matrix(rev(cumsum(rev(exp(eta)))))
+  }
+  n = nrow(y)
+  current_sum = 0
+  start_idx = n
+  stop_idx = n
+  start_o = order(y[,1])
+  while(start_idx>0 && stop_idx >0){
+    if(y[start_o[start_idx],1]<y[ind[stop_idx],2]){
+      r[stop_idx,] = r[stop_idx,] - current_sum
+      stop_idx = stop_idx - 1
+    }else{
+      current_sum = current_sum + exp(eta[start_o[start_idx],])
+      start_idx = start_idx - 1
+    }
   }
   if (total) {
     return(-2*(crossprod(d, eta) - crossprod(d, log(r))))

--- a/R/newS.R
+++ b/R/newS.R
@@ -1,6 +1,17 @@
 newS <- function(y) {
-  ind <- order(y[,1])
-  list(time = as.double(y[ind,1]),
-       fail = as.double(y[ind,2]),
-       ind  = ind)
+  if(ncol(y) == 2){
+    ind <- order(y[,1])
+    list(start_time = as.double(rep(0,nrow(y))),
+         stop_time = as.double(y[ind,1]),
+         fail = as.double(y[ind,2]),
+         ind  = ind)
+  }else if(ncol(y)==3){
+    ind <- order(y[,2])
+    list(start_time = as.double(y[ind,1]),
+         stop_time = as.double(y[ind,2]),
+         fail = as.double(y[ind,3]),
+         ind  = ind)
+  }else{
+    stop('y must be specified as Surv(time,fail) or Surv(start,stop,fail)')
+  }
 }

--- a/R/predict-surv.R
+++ b/R/predict-surv.R
@@ -97,7 +97,7 @@ predict.grpsurv <- function(object, X,
     a <- ifelse(object$fail, (1-w/r)^(1/w), 1)
     S0 <- c(1, cumprod(a))
     H0 <- c(0, cumsum(1-a))
-    x <- c(0, object$time)
+    x <- c(0, object$stop_time)
     for (i in 1:nrow(eta)) {
       S <- S0^exp(eta[i,j])
       H <- H0*exp(eta[i,j])
@@ -113,7 +113,7 @@ predict.grpsurv <- function(object, X,
   if (type %in% c('survival', 'hazard')) {
     if (nrow(eta)==1) val <- val[[1]]
     class(val) <- c('grpsurv.func', class(val))
-    attr(val, 'time') <- object$time
+    attr(val, 'time') <- object$stop_time
   } else if (type == 'median') {
     val <- drop(val)
   }

--- a/R/residuals.R
+++ b/R/residuals.R
@@ -24,7 +24,7 @@ residuals.grpreg <- function(object, lambda, which=1:length(object$lambda), drop
   if (inherits(object, 'grpsurv')) {
     for (j in 1:length(object$lambda)) {
       H <- suppressWarnings(predict(object, which=j, type='hazard'))
-      M <- object$fail - H(object$time) * exp(object$linear.predictors)
+      M <- object$fail - H(object$stop_time) * exp(object$linear.predictors)
       R <- sign(M) * sqrt(-2*(M + object$fail*log(object$fail-M)))
       R <- R[match(1:object$n, object$order),]  # Return in original order
     }

--- a/src/grpreg_init.c
+++ b/src/grpreg_init.c
@@ -7,10 +7,10 @@
 
 /* .Call calls */
 extern SEXP gdfit_glm(SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP);
-extern SEXP gdfit_cox(SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP);
+extern SEXP gdfit_cox(SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP);
 extern SEXP gdfit_gaussian(SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP);
 extern SEXP lcdfit_glm(SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP);
-extern SEXP lcdfit_cox(SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP);
+extern SEXP lcdfit_cox(SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP);
 extern SEXP lcdfit_gaussian(SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP);
 extern SEXP maxgrad(SEXP, SEXP, SEXP, SEXP);
 extern SEXP maxprod(SEXP, SEXP, SEXP, SEXP);
@@ -18,10 +18,10 @@ extern SEXP standardize(SEXP);
 
 static const R_CallMethodDef CallEntries[] = {
   {"gdfit_glm",                (DL_FUNC) &gdfit_glm,                16},
-  {"gdfit_cox",                (DL_FUNC) &gdfit_cox,                15},
+  {"gdfit_cox",                (DL_FUNC) &gdfit_cox,                18},
   {"gdfit_gaussian",           (DL_FUNC) &gdfit_gaussian,           15},
   {"lcdfit_glm",               (DL_FUNC) &lcdfit_glm,               18},
-  {"lcdfit_cox",               (DL_FUNC) &lcdfit_cox,               17},
+  {"lcdfit_cox",               (DL_FUNC) &lcdfit_cox,               20},
   {"lcdfit_gaussian",          (DL_FUNC) &lcdfit_gaussian,          16},
   {"maxgrad",                  (DL_FUNC) &maxgrad,                   4},
   {"maxprod",                  (DL_FUNC) &maxprod,                   4},


### PR DESCRIPTION
@pbreheny I have modified the code to enable start, stop survival times as mentioned in issue #43. This brings grpsurv in line with the functionality of glmnet.

Work still to be done: include a way of 'clustering' rows so that individuals split across multiple rows due to time varying covariates are treated as repeat measurements rather than completely independent rows. (See cluster term of coxph function [here](https://www.rdocumentation.org/packages/survival/versions/3.2-11/topics/coxph))

Happy to discuss any of the changes that I've made.